### PR TITLE
Fix return values from suspicion detection get prediction functions w…

### DIFF
--- a/core/domain/SuspicionDetection.py
+++ b/core/domain/SuspicionDetection.py
@@ -133,7 +133,7 @@ class SuspicionDetection(object):
     @async.synchronize(lock='_inception_buffer_lock')
     def get_inception_prediction(self):
         if not self.inception_buffer:
-            return False
+            return []
         return self.inception_buffer.pop(0)
 
     @async.synchronize(lock='_yolo_buffer_lock')
@@ -147,7 +147,7 @@ class SuspicionDetection(object):
     @async.synchronize(lock='_yolo_buffer_lock')
     def get_yolo_prediction(self):
         if not self.yolo_buffer:
-            return False
+            return []
         return self.yolo_buffer.pop(0)
 
     @async.synchronize(lock='_activity_detector_buffer_lock')
@@ -161,7 +161,7 @@ class SuspicionDetection(object):
     @async.synchronize(lock='_activity_detector_buffer_lock')
     def get_activity_detector_prediction(self):
         if not self.activity_detector_buffer:
-            return False
+            return None
         return self.activity_detector_buffer.pop(0)
 
     @async.synchronize(lock='_event_detector_buffer_lock')
@@ -175,7 +175,7 @@ class SuspicionDetection(object):
     @async.synchronize(lock='_event_detector_buffer_lock')
     def get_event_detector_prediction(self):
         if not self.event_detector_buffer:
-            return False
+            return []
         return self.event_detector_buffer.pop(0)
 
     def detect(self, frame):


### PR DESCRIPTION
The return values from suspicion detection class's get prediction functions should be an empty list in the case when buffer stores a list as its element.